### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,7 @@ setDataReceivedHandler	KEYWORD2
 convertToString	KEYWORD2
 convertStringToRGB	KEYWORD2
 isChannelMatched	KEYWORD2
-setLoggerChannel    KEYWORD2
+setLoggerChannel	KEYWORD2
 
 # Handler helpers
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords